### PR TITLE
Add partial file naming to incomplete files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Finally, execute the file called [run.py](run.py) *(requires Python 3.6+)*.
 Podcasts take a long time to download, so expect the first run to take over an hour
 to complete.
 
-Please do not interrupt the program during downloads, as this will result in
-corrupted files which will have to be manually removed.
+If you interrupt the program while downloading, you may find ```.partial``` files in
+the output directory. They are incomplete downloads and can safely be ignored/deleted.
 
 The program will only download podcasts that you have not already downloaded, meaning
 that any subsequent runs (provided you don't change the download directory) will be

--- a/run.py
+++ b/run.py
@@ -90,10 +90,13 @@ def download_podcast(name, podcast_link, download_path):
               get_video_service_podcast.status_code)
         return
 
-    # Write to file
-    with open(download_path, "wb") as f:
+    # Write to file with partial extension
+    with open(download_path + ".partial", "wb") as f:
         get_video_service_podcast.raw.decode_content = True
         shutil.copyfileobj(get_video_service_podcast.raw, f)
+
+    # Rename completed file
+    os.rename(download_path + ".partial", download_path)
 
     print("Downloaded podcast", name)
 


### PR DESCRIPTION
Any uncompleted files are given a ```.partial``` extension, meaning they will be replaced automatically.

This allows you then to stop/start the program as needed.